### PR TITLE
[#59]Feat: 회원 탈퇴 구현

### DIFF
--- a/src/main/java/com/example/booktalk/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/booktalk/domain/user/controller/UserController.java
@@ -4,10 +4,12 @@ package com.example.booktalk.domain.user.controller;
 import com.example.booktalk.domain.user.dto.request.UserLoginReq;
 import com.example.booktalk.domain.user.dto.request.UserProfileReq;
 import com.example.booktalk.domain.user.dto.request.UserSignupReq;
+import com.example.booktalk.domain.user.dto.request.UserWithdrawReq;
 import com.example.booktalk.domain.user.dto.response.UserLoginRes;
 import com.example.booktalk.domain.user.dto.response.UserProfileGetRes;
 import com.example.booktalk.domain.user.dto.response.UserProfileUpdateRes;
 import com.example.booktalk.domain.user.dto.response.UserSignupRes;
+import com.example.booktalk.domain.user.dto.response.UserWithdrawRes;
 import com.example.booktalk.domain.user.service.UserService;
 import com.example.booktalk.global.security.UserDetailsImpl;
 import jakarta.servlet.http.HttpServletResponse;
@@ -61,5 +63,11 @@ public class UserController {
         return ResponseEntity.status(HttpStatus.OK)
             .body(userService.updateProfile(userId, req, userDetails.getUser().getId()));
 
+    }
+
+    @PutMapping("/withdraw")
+    public ResponseEntity<UserWithdrawRes> withdraw(@RequestBody UserWithdrawReq req,@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        return ResponseEntity.status(HttpStatus.OK)
+            .body(userService.withdraw(req,userDetails.getUser().getId()));
     }
 }

--- a/src/main/java/com/example/booktalk/domain/user/dto/request/UserWithdrawReq.java
+++ b/src/main/java/com/example/booktalk/domain/user/dto/request/UserWithdrawReq.java
@@ -1,0 +1,8 @@
+package com.example.booktalk.domain.user.dto.request;
+
+public record UserWithdrawReq(
+    String password,
+    String passwordCheck
+) {
+
+}

--- a/src/main/java/com/example/booktalk/domain/user/dto/response/UserWithdrawRes.java
+++ b/src/main/java/com/example/booktalk/domain/user/dto/response/UserWithdrawRes.java
@@ -1,0 +1,7 @@
+package com.example.booktalk.domain.user.dto.response;
+
+public record UserWithdrawRes(
+    String message
+) {
+
+}

--- a/src/main/java/com/example/booktalk/domain/user/entity/User.java
+++ b/src/main/java/com/example/booktalk/domain/user/entity/User.java
@@ -84,4 +84,8 @@ public class User extends BaseEntity {
             this.score = 0.0;
         }
     }
+
+    public void withdraw() {
+        this.deleted = true;
+    }
 }

--- a/src/main/java/com/example/booktalk/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/com/example/booktalk/domain/user/exception/UserErrorCode.java
@@ -13,7 +13,7 @@ public enum UserErrorCode implements ErrorCode {
     NOT_FOUND_REFRESH_TOKEN(HttpStatus.NOT_FOUND, "해당 리프레시 토큰을 찾을 수 없습니다."),
     ALREADY_EXIST_EMAIL(HttpStatus.BAD_REQUEST, "이미 가입된 이메일입니다."),
     INVALID_ADMIN_CODE(HttpStatus.BAD_REQUEST, "관리자 인증 번호가 틀렸습니다."),
-    BAD_LOGIN(HttpStatus.BAD_REQUEST, "이메일 또는 패스워드를 확인해주세요."),
+    BAD_LOGIN(HttpStatus.BAD_REQUEST, "패스워드를 확인해주세요."),
     NOT_MATCH_PASSWORD(HttpStatus.BAD_REQUEST, "비밀번호가 일치하지 않습니다."),
     INVALID_PASSWORD_CHECK(HttpStatus.BAD_REQUEST, "비밀번호와 비밀번호 확인이 일치하지 않습니다.");
 


### PR DESCRIPTION
## 개요
회원탈퇴 api 
요청(비밀번호와 비밀번호확인) 
->비밀번호 비밀번호 확인 일치확인
->입력한 비밀번호 저장된 비밀번호 일치 확인
->deleted true로 변경 
->로그인로직에 deleted true일때 예외처리

## 작업사항
- 내용을 적어주세요.

## 변경로직
- 내용을 적어주세요.

## 관련 이슈
close #59 
- 
