### PR TITLE
상품 생성,단건조회,수정,삭제 할때도 이미지가 생성,조회,수정,삭제 되도록 수정

### DIFF
--- a/src/main/java/com/example/booktalk/domain/admin/controller/AdminUserRoleController.java
+++ b/src/main/java/com/example/booktalk/domain/admin/controller/AdminUserRoleController.java
@@ -2,6 +2,8 @@ package com.example.booktalk.domain.admin.controller;
 
 import com.example.booktalk.domain.admin.service.AdminUserRoleService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -14,9 +16,9 @@ public class AdminUserRoleController {
 
     private final AdminUserRoleService adminUserRoleService;
     @PutMapping("/user/{userId}")
-    public void userBlock(
+    public String userBlock(
             @PathVariable Long userId
     ) {
-        adminUserRoleService.userBlock(userId);
+        return adminUserRoleService.userBlock(userId);
     }
 }

--- a/src/main/java/com/example/booktalk/domain/admin/service/AdminUserRoleService.java
+++ b/src/main/java/com/example/booktalk/domain/admin/service/AdminUserRoleService.java
@@ -13,10 +13,12 @@ import org.springframework.transaction.annotation.Transactional;
 public class AdminUserRoleService {
     private final UserRepository userRepository;
     @Transactional
-    public void userBlock(Long userId){
+    public String userBlock(Long userId){
         User user=findUser(userId);
         UserRoleType role = UserRoleType.BLOCK;
         user.updateRole(role);
+
+        return "차단 되었습니다";
     }
     private User findUser(Long id) {
         return userRepository.findById(id)

--- a/src/main/java/com/example/booktalk/domain/imageFile/controller/ImageController.java
+++ b/src/main/java/com/example/booktalk/domain/imageFile/controller/ImageController.java
@@ -27,11 +27,11 @@ public class ImageController {
 
     @PostMapping
     @ResponseBody
-    public ImageCreateRes createImage(@AuthenticationPrincipal UserDetailsImpl userDetails,
+    public List<ImageCreateRes> createImage(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                       @RequestPart("productId") CreateImageReq req,
-                                      @RequestParam("upload") MultipartFile file) throws IOException {
+                                      @RequestParam("upload") List<MultipartFile> files) throws IOException {
 
-        return imageFileService.createImage(userDetails.getUser().getId(),req.productId(),file);
+        return imageFileService.createImage(userDetails.getUser().getId(),req.productId(),files);
     }
     @GetMapping("/{imageId}") //단일 조회
     public ImageGetRes getImage(@RequestBody GetImageReq req,

--- a/src/main/java/com/example/booktalk/domain/imageFile/controller/ImageController.java
+++ b/src/main/java/com/example/booktalk/domain/imageFile/controller/ImageController.java
@@ -42,12 +42,11 @@ public class ImageController {
     public List<ImageListRes> getImages(@RequestBody GetImageReq req) {
          return imageFileService.getImages(req.productId());
     }
-    @PutMapping("/{imageId}") //이미지 수정
-    public ImageUpdateRes updateImage(@AuthenticationPrincipal UserDetailsImpl userDetails,
+    @PutMapping//이미지 수정
+    public List<ImageCreateRes> updateImage(@AuthenticationPrincipal UserDetailsImpl userDetails,
                                       @RequestPart("productId") CreateImageReq req,
-                                      @PathVariable Long imageId,
-                                      @RequestParam("upload") MultipartFile file) throws IOException {
-        return imageFileService.updateImage(userDetails.getUser().getId(), req.productId(),imageId,file);
+                                      @RequestParam("upload") List<MultipartFile> files) throws IOException {
+        return imageFileService.updateImage(userDetails.getUser().getId(), req.productId(),files);
     }
     @DeleteMapping //이미지 삭제
     public ImageDeleteRes deleteImage(@AuthenticationPrincipal UserDetailsImpl userDetails,

--- a/src/main/java/com/example/booktalk/domain/imageFile/controller/ImageController.java
+++ b/src/main/java/com/example/booktalk/domain/imageFile/controller/ImageController.java
@@ -49,11 +49,10 @@ public class ImageController {
                                       @RequestParam("upload") MultipartFile file) throws IOException {
         return imageFileService.updateImage(userDetails.getUser().getId(), req.productId(),imageId,file);
     }
-    @DeleteMapping("/{imageId}") //이미지 삭제
+    @DeleteMapping //이미지 삭제
     public ImageDeleteRes deleteImage(@AuthenticationPrincipal UserDetailsImpl userDetails,
-                                      @RequestBody DeleteImageReq req,
-                                      @PathVariable Long imageId) {
-        return imageFileService.deleteImage(userDetails.getUser().getId(), req.productId(),imageId);
+                                      @RequestBody DeleteImageReq req) {
+        return imageFileService.deleteImage(userDetails.getUser().getId(), req.productId());
     }
 
 

--- a/src/main/java/com/example/booktalk/domain/imageFile/dto/response/ImageCreateRes.java
+++ b/src/main/java/com/example/booktalk/domain/imageFile/dto/response/ImageCreateRes.java
@@ -1,5 +1,5 @@
 package com.example.booktalk.domain.imageFile.dto.response;
 
-public record ImageCreateRes(Long id,String imagePathUrl) {
+public record ImageCreateRes(String imagePathUrl) {
 
 }

--- a/src/main/java/com/example/booktalk/domain/imageFile/dto/response/ImageListRes.java
+++ b/src/main/java/com/example/booktalk/domain/imageFile/dto/response/ImageListRes.java
@@ -1,4 +1,4 @@
 package com.example.booktalk.domain.imageFile.dto.response;
 
-public record ImageListRes(Long id,String imagePathUrl) {
+public record ImageListRes(String imagePathUrl) {
 }

--- a/src/main/java/com/example/booktalk/domain/imageFile/service/ImageFileService.java
+++ b/src/main/java/com/example/booktalk/domain/imageFile/service/ImageFileService.java
@@ -44,7 +44,7 @@ public class ImageFileService {
     private String bucket;
 
     public List<ImageCreateRes> createImage(Long userId, Long productId,List<MultipartFile> files) throws IOException {
-        List<ImageCreateRes> imageResponses = new ArrayList<>();
+        List<ImageCreateRes> imageCreateResList = new ArrayList<>();
 
         for (MultipartFile file : files) {
             String imagePathUrl = imageUpload(file);
@@ -57,9 +57,9 @@ public class ImageFileService {
                     .build();
             imageFileRepository.save(imageFile);
             ImageCreateRes imageResponse = new ImageCreateRes(imageFile.getId(), imageFile.getImagePathUrl());
-            imageResponses.add(imageResponse);
+            imageCreateResList.add(imageResponse);
         }
-        return imageResponses;
+        return imageCreateResList;
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/example/booktalk/domain/imageFile/service/ImageFileService.java
+++ b/src/main/java/com/example/booktalk/domain/imageFile/service/ImageFileService.java
@@ -76,14 +76,9 @@ public class ImageFileService {
                 .toList();
     }
 
-    @Transactional
-    public ImageUpdateRes updateImage(Long userId, Long productId, Long imageId, @RequestParam("upload") MultipartFile file) throws IOException {
-        User user = userRepository.findUserByIdWithThrow(userId);
-        String image = imageUpload(file);
-        ImageFile imageFile = imageFileRepository.findImageFileByProductIdAndIdWithThrow(productId, imageId);
-        validateProductUser(user, imageFile);
-        imageFile.updateImage(image);
-        return new ImageUpdateRes(imageFile.getId(), imageFile.getImagePathUrl());
+    public List<ImageCreateRes> updateImage(Long userId, Long productId,List<MultipartFile> files) throws IOException {
+        deleteImage(userId,productId);
+        return createImage(userId,productId,files);
     }
 
     public ImageDeleteRes deleteImage(Long userId, Long productId) {

--- a/src/main/java/com/example/booktalk/domain/imageFile/service/ImageFileService.java
+++ b/src/main/java/com/example/booktalk/domain/imageFile/service/ImageFileService.java
@@ -86,11 +86,13 @@ public class ImageFileService {
         return new ImageUpdateRes(imageFile.getId(), imageFile.getImagePathUrl());
     }
 
-    public ImageDeleteRes deleteImage(Long userId, Long productId, Long imageId) {
+    public ImageDeleteRes deleteImage(Long userId, Long productId) {
         User user = userRepository.findUserByIdWithThrow(userId);
-        ImageFile imageFile = imageFileRepository.findImageFileByProductIdAndIdWithThrow(productId, imageId);
-        validateProductUser(user, imageFile);
-        imageFileRepository.delete(imageFile);
+        List<ImageFile> imageFileList = imageFileRepository.findByProductId(productId);
+        for(ImageFile imageFile:imageFileList) {
+            validateProductUser(user, imageFile);
+            imageFileRepository.delete(imageFile);
+        }
         return new ImageDeleteRes("삭제가 완료되었습니다.");
     }
 

--- a/src/main/java/com/example/booktalk/domain/imageFile/service/ImageFileService.java
+++ b/src/main/java/com/example/booktalk/domain/imageFile/service/ImageFileService.java
@@ -27,6 +27,7 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -42,17 +43,23 @@ public class ImageFileService {
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
 
-    public ImageCreateRes createImage(Long userId, Long productId, @RequestParam("upload") MultipartFile file) throws IOException {
-        String imagePathUrl = imageUpload(file);
-        User user = userRepository.findUserByIdWithThrow(userId);
-        Product product = productRepository.findProductByIdWithThrow(productId);
-        ImageFile imageFile = ImageFile.builder()
-                .imagePathUrl(imagePathUrl)
-                .user(user)
-                .product(product)
-                .build();
-        imageFileRepository.save(imageFile);
-        return new ImageCreateRes(imageFile.getId(), imageFile.getImagePathUrl());
+    public List<ImageCreateRes> createImage(Long userId, Long productId,List<MultipartFile> files) throws IOException {
+        List<ImageCreateRes> imageResponses = new ArrayList<>();
+
+        for (MultipartFile file : files) {
+            String imagePathUrl = imageUpload(file);
+            User user = userRepository.findUserByIdWithThrow(userId);
+            Product product = productRepository.findProductByIdWithThrow(productId);
+            ImageFile imageFile = ImageFile.builder()
+                    .imagePathUrl(imagePathUrl)
+                    .user(user)
+                    .product(product)
+                    .build();
+            imageFileRepository.save(imageFile);
+            ImageCreateRes imageResponse = new ImageCreateRes(imageFile.getId(), imageFile.getImagePathUrl());
+            imageResponses.add(imageResponse);
+        }
+        return imageResponses;
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/com/example/booktalk/domain/imageFile/service/ImageFileService.java
+++ b/src/main/java/com/example/booktalk/domain/imageFile/service/ImageFileService.java
@@ -72,7 +72,7 @@ public class ImageFileService {
     public List<ImageListRes> getImages(Long productId) {
         List<ImageFile> imageList = imageFileRepository.findByProductId(productId);
         return imageList.stream()
-                .map(imageFile -> new ImageListRes(imageFile.getId(), imageFile.getImagePathUrl()))
+                .map(imageFile -> new ImageListRes(imageFile.getImagePathUrl()))
                 .toList();
     }
 

--- a/src/main/java/com/example/booktalk/domain/imageFile/service/ImageFileService.java
+++ b/src/main/java/com/example/booktalk/domain/imageFile/service/ImageFileService.java
@@ -56,7 +56,7 @@ public class ImageFileService {
                     .product(product)
                     .build();
             imageFileRepository.save(imageFile);
-            ImageCreateRes imageResponse = new ImageCreateRes(imageFile.getId(), imageFile.getImagePathUrl());
+            ImageCreateRes imageResponse = new ImageCreateRes( imageFile.getImagePathUrl());
             imageCreateResList.add(imageResponse);
         }
         return imageCreateResList;

--- a/src/main/java/com/example/booktalk/domain/product/controller/ProductController.java
+++ b/src/main/java/com/example/booktalk/domain/product/controller/ProductController.java
@@ -42,9 +42,10 @@ public class ProductController {
     public ProductUpdateRes updateProduct(
         @AuthenticationPrincipal UserDetailsImpl userDetails,
         @PathVariable Long productId,
-        @RequestBody ProductUpdateReq req
-    ) {
-        return productService.updateProduct(userDetails.getUser().getId(), productId, req);
+        @RequestPart("req") ProductUpdateReq req,
+        @RequestParam("upload") List<MultipartFile> files
+    ) throws IOException {
+        return productService.updateProduct(userDetails.getUser().getId(), productId, req,files);
     }
 
     @DeleteMapping("/{productId}")

--- a/src/main/java/com/example/booktalk/domain/product/controller/ProductController.java
+++ b/src/main/java/com/example/booktalk/domain/product/controller/ProductController.java
@@ -13,18 +13,13 @@ import com.example.booktalk.domain.product.dto.response.ProductTopLikesListRes;
 import com.example.booktalk.domain.product.dto.response.ProductUpdateRes;
 import com.example.booktalk.domain.product.service.ProductService;
 import com.example.booktalk.global.security.UserDetailsImpl;
+
+import java.io.IOException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.DeleteMapping;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
@@ -36,9 +31,10 @@ public class ProductController {
     @PostMapping
     public ProductCreateRes createProduct(
         @AuthenticationPrincipal UserDetailsImpl userDetails,
-        @RequestBody ProductCreateReq req
-    ) {
-        return productService.createProduct(userDetails.getUser().getId(), req);
+        @RequestPart("req") ProductCreateReq req,
+        @RequestParam("upload") List<MultipartFile> files
+    ) throws IOException {
+        return productService.createProduct(userDetails.getUser().getId(), req,files);
 
     }
 

--- a/src/main/java/com/example/booktalk/domain/product/dto/response/ProductCreateRes.java
+++ b/src/main/java/com/example/booktalk/domain/product/dto/response/ProductCreateRes.java
@@ -1,11 +1,13 @@
 package com.example.booktalk.domain.product.dto.response;
 
+import com.example.booktalk.domain.imageFile.dto.response.ImageCreateRes;
 import com.example.booktalk.domain.product.entity.Region;
 import com.example.booktalk.domain.user.dto.response.UserRes;
 import java.util.List;
 
 public record ProductCreateRes(Long id, String name, Long quantity, Long price,
                                Region region, Boolean finished, UserRes user, String content,
-                               List<String> categoryList) {
+                               List<String> categoryList,
+                               List<ImageCreateRes> imageCreateResList) {
 
 }

--- a/src/main/java/com/example/booktalk/domain/product/dto/response/ProductGetRes.java
+++ b/src/main/java/com/example/booktalk/domain/product/dto/response/ProductGetRes.java
@@ -1,5 +1,6 @@
 package com.example.booktalk.domain.product.dto.response;
 
+import com.example.booktalk.domain.imageFile.dto.response.ImageListRes;
 import com.example.booktalk.domain.product.entity.Region;
 import com.example.booktalk.domain.user.dto.response.UserRes;
 import java.util.List;
@@ -7,6 +8,7 @@ import java.util.List;
 public record ProductGetRes(Long id, String name, Long price, Long quantity, UserRes user,
                             Region region, List<String> categories, Long productLikes,
                             String content,
-                            Boolean finished) {
+                            Boolean finished,
+                            List<ImageListRes> imageListRes) {
 
 }

--- a/src/main/java/com/example/booktalk/domain/product/dto/response/ProductUpdateRes.java
+++ b/src/main/java/com/example/booktalk/domain/product/dto/response/ProductUpdateRes.java
@@ -1,5 +1,6 @@
 package com.example.booktalk.domain.product.dto.response;
 
+import com.example.booktalk.domain.imageFile.dto.response.ImageCreateRes;
 import com.example.booktalk.domain.product.entity.Region;
 import com.example.booktalk.domain.user.dto.response.UserRes;
 import java.util.List;
@@ -7,6 +8,7 @@ import java.util.List;
 public record ProductUpdateRes(Long id, String name, Long quantity, Long price,
                                Region regions, Boolean finished, UserRes user, Long productLikes,
                                String content,
-                               List<String> categoryList) {
+                               List<String> categoryList,
+                               List<ImageCreateRes> imageCreateResList) {
 
 }

--- a/src/main/java/com/example/booktalk/domain/product/service/ProductService.java
+++ b/src/main/java/com/example/booktalk/domain/product/service/ProductService.java
@@ -4,6 +4,8 @@ import com.example.booktalk.domain.category.entity.Category;
 import com.example.booktalk.domain.category.exception.CategoryErrorCode;
 import com.example.booktalk.domain.category.exception.NotFoundCategoryException;
 import com.example.booktalk.domain.category.repository.CategoryRepository;
+import com.example.booktalk.domain.imageFile.dto.response.ImageCreateRes;
+import com.example.booktalk.domain.imageFile.service.ImageFileService;
 import com.example.booktalk.domain.product.dto.request.ProductCreateReq;
 import com.example.booktalk.domain.product.dto.request.ProductUpdateReq;
 import com.example.booktalk.domain.product.dto.response.ProductCreateRes;
@@ -23,11 +25,14 @@ import com.example.booktalk.domain.productcategory.repository.ProductCategoryRep
 import com.example.booktalk.domain.user.dto.response.UserRes;
 import com.example.booktalk.domain.user.entity.User;
 import com.example.booktalk.domain.user.repository.UserRepository;
+
+import java.io.IOException;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Service
 @RequiredArgsConstructor
@@ -38,8 +43,9 @@ public class ProductService {
     private final UserRepository userRepository;
     private final CategoryRepository categoryRepository;
     private final ProductCategoryRepository productCategoryRepository;
+    private final ImageFileService imageFileService;
 
-    public ProductCreateRes createProduct(Long userId, ProductCreateReq req) {
+    public ProductCreateRes createProduct(Long userId, ProductCreateReq req, List<MultipartFile> files) throws IOException {
 
         User user = userRepository.findUserByIdWithThrow(userId);
 
@@ -53,13 +59,15 @@ public class ProductService {
             .build();
         product = productRepository.save(product);
         addCategory(req.categoryList(), product);
-
         UserRes userRes = new UserRes(user.getId(), user.getNickname());
+
+        List<ImageCreateRes> imageCreateResList =imageFileService.createImage(userId, product.getId(), files);
+
 
         return new ProductCreateRes(product.getId(), product.getName(), product.getQuantity(),
             product.getPrice()
             , product.getRegion(), product.getFinished(), userRes, product.getContent(),
-            req.categoryList());
+            req.categoryList(), imageCreateResList);
         //TODO 생성자로 한줄정리
 
     }

--- a/src/main/java/com/example/booktalk/domain/product/service/ProductService.java
+++ b/src/main/java/com/example/booktalk/domain/product/service/ProductService.java
@@ -72,11 +72,13 @@ public class ProductService {
 
     }
 
-    public ProductUpdateRes updateProduct(Long userId, Long productId, ProductUpdateReq req) {
+    public ProductUpdateRes updateProduct(Long userId, Long productId, ProductUpdateReq req, List<MultipartFile> files) throws IOException {
 
         User user = userRepository.findUserByIdWithThrow(userId);
         Product product = productRepository.findProductByIdWithThrow(productId);
         validateProductUser(user, product);
+
+        List<ImageCreateRes> imageCreateResList =imageFileService.updateImage(userId, productId,files);
 
         product.update(req);
         updateCategory(req.categoryList(), product);
@@ -84,7 +86,7 @@ public class ProductService {
         return new ProductUpdateRes(product.getId(), product.getName(),
             product.getQuantity(), product.getPrice(), product.getRegion(),
             product.getFinished(), userRes, product.getProductLikeCnt(), product.getContent(),
-            req.categoryList());
+            req.categoryList(),imageCreateResList);
 
     }
 

--- a/src/main/java/com/example/booktalk/domain/product/service/ProductService.java
+++ b/src/main/java/com/example/booktalk/domain/product/service/ProductService.java
@@ -5,6 +5,7 @@ import com.example.booktalk.domain.category.exception.CategoryErrorCode;
 import com.example.booktalk.domain.category.exception.NotFoundCategoryException;
 import com.example.booktalk.domain.category.repository.CategoryRepository;
 import com.example.booktalk.domain.imageFile.dto.response.ImageCreateRes;
+import com.example.booktalk.domain.imageFile.dto.response.ImageListRes;
 import com.example.booktalk.domain.imageFile.service.ImageFileService;
 import com.example.booktalk.domain.product.dto.request.ProductCreateReq;
 import com.example.booktalk.domain.product.dto.request.ProductUpdateReq;
@@ -102,11 +103,12 @@ public class ProductService {
                 return productCategory.getCategory().getName();
             })
             .toList();
+        List<ImageListRes> imageListRes =imageFileService.getImages(productId);
 
         return new ProductGetRes(product.getId(), product.getName(), product.getPrice()
             , product.getQuantity(), userRes, product.getRegion(), categories,
             product.getProductLikeCnt(), product.getContent(),
-            product.getFinished());
+            product.getFinished(),imageListRes);
 
     }
 

--- a/src/main/java/com/example/booktalk/domain/product/service/ProductService.java
+++ b/src/main/java/com/example/booktalk/domain/product/service/ProductService.java
@@ -214,6 +214,7 @@ public class ProductService {
         User user = userRepository.findUserByIdWithThrow(userId);
         Product product = productRepository.findProductByIdWithThrow(productId);
         validateProductUser(user, product);
+        imageFileService.deleteImage(userId,productId);
 
         product.deleted();
 


### PR DESCRIPTION
## 개요
상품 생성,단건조회,수정,삭제 할때도 이미지가 생성,조회,수정,삭제 되도록 수정

## 작업사항
- 상품 생성,단건조회,수정,삭제 할때도 이미지가 생성,조회,수정,삭제 되도록 수정

## 변경로직
- 상품 생성,단건조회,수정,삭제 할때도 이미지가 생성,조회,수정,삭제 되도록 수정

## 관련 이슈
- 
