### PR TITLE
상품 다건 조회할때 첫번째 이미지만 조회 되도록 수정,유저에서 프로필 수정할때 이미지도 수정 가능하게 수정

### DIFF
--- a/src/main/java/com/example/booktalk/domain/product/dto/response/ProductListRes.java
+++ b/src/main/java/com/example/booktalk/domain/product/dto/response/ProductListRes.java
@@ -1,11 +1,14 @@
 package com.example.booktalk.domain.product.dto.response;
 
+import com.example.booktalk.domain.imageFile.dto.response.ImageListRes;
+import com.example.booktalk.domain.imageFile.entity.ImageFile;
 import com.example.booktalk.domain.product.entity.Region;
 import java.util.List;
 
 public record ProductListRes(Long id, String name, Long price, Long quantity,
                              Long productLikes, List<String> categories,
-                             Region region) {
+                             Region region,
+                             ImageListRes imageListRes) {
 
 
 }

--- a/src/main/java/com/example/booktalk/domain/product/service/ProductService.java
+++ b/src/main/java/com/example/booktalk/domain/product/service/ProductService.java
@@ -6,6 +6,7 @@ import com.example.booktalk.domain.category.exception.NotFoundCategoryException;
 import com.example.booktalk.domain.category.repository.CategoryRepository;
 import com.example.booktalk.domain.imageFile.dto.response.ImageCreateRes;
 import com.example.booktalk.domain.imageFile.dto.response.ImageListRes;
+import com.example.booktalk.domain.imageFile.entity.ImageFile;
 import com.example.booktalk.domain.imageFile.service.ImageFileService;
 import com.example.booktalk.domain.product.dto.request.ProductCreateReq;
 import com.example.booktalk.domain.product.dto.request.ProductUpdateReq;
@@ -120,8 +121,11 @@ public class ProductService {
 
         List<Product> productList = productRepository.findAllByDeletedFalse(sort);
 
+
+
         return productList.stream()
             .map(product -> {
+                List<ImageListRes> imageListRes=imageFileService.getImages(product.getId());
 
                 List<String> categories = product.getProductCategoryList().stream()
                     .map(productCategory -> {
@@ -131,7 +135,7 @@ public class ProductService {
 
                 return new ProductListRes(product.getId(), product.getName(), product.getPrice(),
                     product.getQuantity(), product.getProductLikeCnt(), categories,
-                    product.getRegion());
+                    product.getRegion(),imageListRes.get(0));
             })
             .toList();
 

--- a/src/main/java/com/example/booktalk/domain/user/controller/UserController.java
+++ b/src/main/java/com/example/booktalk/domain/user/controller/UserController.java
@@ -66,9 +66,11 @@ public class UserController {
 
     @PutMapping("/{userId}")
     public ResponseEntity<UserProfileUpdateRes> updateProfile(@PathVariable Long userId,
-        @RequestBody UserProfileReq req, @AuthenticationPrincipal UserDetailsImpl userDetails) {
+                                                              @RequestPart("req") UserProfileReq req,
+                                                              @AuthenticationPrincipal UserDetailsImpl userDetails,
+                                                              @RequestParam("upload") MultipartFile file) throws IOException {
         return ResponseEntity.status(HttpStatus.OK)
-            .body(userService.updateProfile(userId, req, userDetails.getUser().getId()));
+            .body(userService.updateProfile(userId, req, userDetails.getUser().getId(),file));
 
     }
 

--- a/src/main/java/com/example/booktalk/domain/user/dto/response/UserProfileUpdateRes.java
+++ b/src/main/java/com/example/booktalk/domain/user/dto/response/UserProfileUpdateRes.java
@@ -1,10 +1,13 @@
 package com.example.booktalk.domain.user.dto.response;
 
+import com.example.booktalk.domain.imageFile.dto.response.ImageCreateRes;
+
 public record UserProfileUpdateRes(
     Long id, String nickname, String email,
     String description,
     String location,
-    String phone
+    String phone,
+    ImageCreateRes imageCreateRes
 ) {
 
 }

--- a/src/main/java/com/example/booktalk/domain/user/service/UserService.java
+++ b/src/main/java/com/example/booktalk/domain/user/service/UserService.java
@@ -1,6 +1,7 @@
 package com.example.booktalk.domain.user.service;
 
 
+import com.example.booktalk.domain.imageFile.dto.response.ImageCreateRes;
 import com.example.booktalk.domain.imageFile.dto.response.ImageGetRes;
 import com.example.booktalk.domain.imageFile.service.ImageFileService;
 import com.example.booktalk.domain.user.dto.request.UserLoginReq;
@@ -135,7 +136,7 @@ public class UserService {
     }
 
     public UserProfileUpdateRes updateProfile(Long userId, UserProfileReq req,
-        Long userDetailsId) {
+        Long userDetailsId,MultipartFile file) throws IOException {
         String password = req.password();
 //        String newPassword = passwordEncoder.encode(req.newPassword());
 //        String newPasswordCheck = req.newPasswordCheck();
@@ -160,8 +161,15 @@ public class UserService {
         user.updateProfile(description, phone, location, nickname);
         userRepository.save(user);
 
+        ImageCreateRes imageCreateRes;
+        if (file != null && !file.isEmpty()) {
+            imageCreateRes = imageFileService.updateProfileImage(userId, file);
+        }else {
+            imageCreateRes=imageFileService.deleteProfileImage(user);
+        }
+
         return new UserProfileUpdateRes(user.getId(), nickname, user.getEmail(), description,
-            location, user.getPhone());
+            location, user.getPhone(),imageCreateRes);
     }
 
 


### PR DESCRIPTION
## 개요
상품 다건 조회할때 첫번째 이미지만 조회 되도록 수정,유저에서 프로필 수정할때 이미지도 수정 가능하게 수정

## 작업사항
- 상품 다건 조회할때 첫번째 이미지만 조회 되도록 수정,유저에서 프로필 수정할때 이미지도 수정 가능하게 수정

## 변경로직
- 상품 다건 조회할때 첫번째 이미지만 조회 되도록 수정,유저에서 프로필 수정할때 이미지도 수정 가능하게 수정

## 관련 이슈
- 
